### PR TITLE
RunTask implements IConnectable

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,7 +26,7 @@ Name|Description
 
 
 
-__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable)
+__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable), [IConnectable](#aws-cdk-aws-ec2-iconnectable)
 __Extends__: [Construct](#aws-cdk-core-construct)
 
 ### Initializer
@@ -60,6 +60,7 @@ new RunTask(scope: Construct, id: string, props: RunTaskProps)
 Name | Type | Description 
 -----|------|-------------
 **cluster** | <code>[ICluster](#aws-cdk-aws-ecs-icluster)</code> | <span></span>
+**connections** | <code>[Connections](#aws-cdk-aws-ec2-connections)</code> | makes RunTask "connectable".
 **securityGroup** | <code>[ISecurityGroup](#aws-cdk-aws-ec2-isecuritygroup)</code> | fargate task security group.
 **vpc** | <code>[IVpc](#aws-cdk-aws-ec2-ivpc)</code> | <span></span>
 **runOnceResource**? | <code>[AwsCustomResource](#aws-cdk-custom-resources-awscustomresource)</code> | The custom resource of the runOnce execution.<br/>__*Optional*__

--- a/src/run-task.ts
+++ b/src/run-task.ts
@@ -72,7 +72,7 @@ export interface RunTaskProps {
   readonly capacityProviderStrategy?: ecs.CapacityProviderStrategy[];
 }
 
-export class RunTask extends Construct {
+export class RunTask extends Construct implements ec2.IConnectable {
   readonly vpc: ec2.IVpc;
   readonly cluster: ecs.ICluster;
   /**
@@ -83,6 +83,10 @@ export class RunTask extends Construct {
    * fargate task security group
    */
   readonly securityGroup: ec2.ISecurityGroup;
+  /**
+   * makes RunTask "connectable"
+   */
+  readonly connections: ec2.Connections;
   constructor(scope: Construct, id: string, props: RunTaskProps) {
     super(scope, id);
 
@@ -95,6 +99,7 @@ export class RunTask extends Construct {
     this.vpc = vpc;
     this.cluster = cluster;
     this.securityGroup = props.securityGroup ?? new ec2.SecurityGroup(this, 'FargateSecurityGroup', { vpc });
+    this.connections = new ec2.Connections({ securityGroups: [this.securityGroup] });
 
     if (props.schedule) {
       new Rule(this, 'ScheduleRule', {


### PR DESCRIPTION
Implementing [IConnectable](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-ec2.Connections.html) allows us to manage connections from/to the RunTask, on outside of the construct, for example on Stack, by using e.g. `.allowTo()` method.

Example usage:

```ts
database = new rds.DatabaseInstance(stack, "Database");

runTask = new RunTask(stack, "RunTask", { taskDefinition });

runTask.connections.allowTo(
  database,
  Port.tcp(database.instanceEndpoint.port),
  `allow traffic to database port tcp/${database.instanceEndpoint.port}`
);
```

This allows the task to connect to the database instance.